### PR TITLE
Update post_form method for Crystal 0.24.1

### DIFF
--- a/src/mastodon/rest/client.cr
+++ b/src/mastodon/rest/client.cr
@@ -18,7 +18,7 @@ module Mastodon
       end
 
       def post(path : String, form : String | Hash(String, String) = "")
-        response = @http_client.post_form(path, form, default_headers)
+        response = @http_client.post(path, form: form, headers: default_headers)
         proccess_response(response)
       end
 


### PR DESCRIPTION
Crystal 0.24.1 add a breaking change on `post_form`.
See the concerned commit: https://github.com/crystal-lang/crystal/commit/2a46e3c55f3149203d114de27bd890422b615119